### PR TITLE
Pin rbs to 4.x

### DIFF
--- a/decode.gemspec
+++ b/decode.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
 	spec.required_ruby_version = ">= 3.3"
 	
 	spec.add_dependency "prism"
-	spec.add_dependency "rbs"
+	spec.add_dependency "rbs", "~> 4.0"
 end


### PR DESCRIPTION
## Summary
- Constrain the rbs dependency to 4.x so the code uses the expected TypeParam API

## Testing
- bundle exec sus test/decode/rbs/class.rb test/decode/rbs/generator.rb